### PR TITLE
Add cvar to list weapons to sound on, remove fake client check for hrcbot compatability

### DIFF
--- a/addons/sourcemod/scripting/damagesound.sp
+++ b/addons/sourcemod/scripting/damagesound.sp
@@ -186,8 +186,8 @@ public OnPluginStart()
 	
 	decl String:temp[200];
 	GetConVarString(cvar_actonweapons,temp,sizeof(temp));
-	if(!StrEqual(temp,"")){
-		ExplodeString(temp," ",actonWeapons,sizeof(actonWeapons),32);
+	if(temp[0] != '\0'){
+		ExplodeString(temp," ",actonWeapons,sizeof(actonWeapons), sizeof(actonWeapons[]));
 	}
 
 	PrintToServer("[%s] Plugin loaded... (v%s)",PLUGIN_NAME,PLUGIN_VERSION);
@@ -234,7 +234,7 @@ stock bool:IsSoundFileOk(const String:tempsoundpath[]){
 bool:IsWeaponSoundable(String:weapon[])
 {
 	new i=0;
-	if(StrEqual(actonWeapons[0],"")){
+	if(actonWeapons[0][0] == '\0'){
 		return true;
 	}
 	for(i=0;i<sizeof(actonWeapons);i++){

--- a/addons/sourcemod/scripting/damagesound.sp
+++ b/addons/sourcemod/scripting/damagesound.sp
@@ -184,11 +184,6 @@ public OnPluginStart()
 	
 	RegConsoleCmd("sm_soundtest",Command_SoundTest,"damagesound test soound");
 	
-	decl String:temp[200];
-	GetConVarString(cvar_actonweapons,temp,sizeof(temp));
-	if(temp[0] != '\0'){
-		ExplodeString(temp," ",actonWeapons,sizeof(actonWeapons), sizeof(actonWeapons[]));
-	}
 
 	PrintToServer("[%s] Plugin loaded... (v%s)",PLUGIN_NAME,PLUGIN_VERSION);
 }
@@ -205,6 +200,13 @@ public OnConfigsExecuted(){
 	
 		strcopy(soundpath,sizeof(soundpath),tempsoundpath);
 	}
+
+	decl String:temp[200];
+	GetConVarString(cvar_actonweapons,temp,sizeof(temp));
+	if(temp[0] != '\0'){
+		ExplodeString(temp," ",actonWeapons,sizeof(actonWeapons), sizeof(actonWeapons[]));
+	}
+
 }
 
 stock bool:IsSoundFileOk(const String:tempsoundpath[]){
@@ -235,6 +237,7 @@ bool:IsWeaponSoundable(String:weapon[])
 {
 	new i=0;
 	if(actonWeapons[0][0] == '\0'){
+//		PrintToServer("No acton weapons configured %s", actonWeapons[0]);
 		return true;
 	}
 	for(i=0;i<sizeof(actonWeapons);i++){
@@ -369,7 +372,7 @@ public Action:Event_Death(Handle:event, const String:name[], bool:dontBroadcast)
 public Action:Event_Hurt(Handle:event, const String:name[], bool:dontBroadcast)
 {	
 	decl String:weapon[32];	
-	
+
 	if(!GetConVarBool(cvar_soundmaster_enable)){
 		return;
 	}
@@ -377,7 +380,7 @@ public Action:Event_Hurt(Handle:event, const String:name[], bool:dontBroadcast)
 
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
 	new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
-	if(!client_enable[client]){
+	if(!client_enable[attacker]){
 		return;
 	}
 

--- a/addons/sourcemod/scripting/damagesound.sp
+++ b/addons/sourcemod/scripting/damagesound.sp
@@ -291,7 +291,7 @@ public OnClientConnected(client){
 
 public OnClientPutInServer(client){
 	
-	if(IsClientConnected(client) && !IsClientSourceTV(client)){		//!IsFakeClient(client)){	
+	if(IsClientConnected(client) && !IsClientSourceTV(client)){
 		
 		if(AreClientCookiesCached(client)){
 			
@@ -309,7 +309,7 @@ public OnClientPutInServer(client){
 
 public OnClientCookiesCached(client){
 	
-	if(IsClientInGame(client) && !IsClientSourceTV(client)){		//IsFakeClient(client)){
+	if(IsClientInGame(client) && !IsClientSourceTV(client)){
 		
 		loadClientCookiesFor(client);	
 	}

--- a/addons/sourcemod/scripting/damagesound.sp
+++ b/addons/sourcemod/scripting/damagesound.sp
@@ -238,7 +238,7 @@ bool:IsWeaponSoundable(String:weapon[])
 		return true;
 	}
 	for(i=0;i<sizeof(actonWeapons);i++){
-		PrintToServer("'%s' = '%s'", actonWeapons[i], weapon);
+//		PrintToServer("'%s' = '%s'", actonWeapons[i], weapon);
 		if(StrEqual(actonWeapons[i],weapon)){
 			return true;
 		}
@@ -382,15 +382,15 @@ public Action:Event_Hurt(Handle:event, const String:name[], bool:dontBroadcast)
 	}
 
 	GetClientWeapon(attacker,weapon,sizeof(weapon));
-	PrintToServer("damagesound: attacker=%d weapon=%s", attacker, weapon);	
+//	PrintToServer("damagesound: attacker=%d weapon=%s", attacker, weapon);	
 	
 	if(Client_IsValid(client) && Client_IsValid(attacker) && (client != attacker)){
 		
 		if(!IsWeaponSoundable(weapon)){
-			PrintToServer("damagesound: No make damage sound for %s",weapon);
+//			PrintToServer("damagesound: No make damage sound for %s",weapon);
 			return;
 		} else {
-			PrintToServer("damagesound: Make damage sound for %s",weapon);
+//			PrintToServer("damagesound: Make damage sound for %s",weapon);
 		}
 
 		new Float:thetime = GetGameTime();


### PR DESCRIPTION
Hello:

This request contains the following changes:
- Add sm_damagesound_actonweapon cvar to specify what weapons to sound on (space delimited)
- Removes IsFakeClient check so that hrcbot's are acted upon.  
- Adds IsClientSourceTv checks
- A typo fix here or there
- Increment version to 1.6

I have left in commented out PrintToServer(..) statements for debugging purposes.

Thanks

[foo] bar
